### PR TITLE
Organize KRX data utilities

### DIFF
--- a/krx/__init__.py
+++ b/krx/__init__.py
@@ -1,0 +1,21 @@
+"""Convenient accessors for Korean stock market data via :mod:`pykrx`.
+
+This package provides a small collection of wrappers around the `pykrx`
+project.  It focuses on index level OHLCV data and trading statistics broken
+down by investor type, which are useful for analysing phenomena such as the
+*Korean cryptocurrency premium*.
+"""
+
+from .indices import fetch_index_ohlcv, fetch_indices_ohlcv, fetch_index_volume
+from .trading import (
+    fetch_trading_value_by_investor,
+    fetch_trading_volume_by_investor,
+)
+
+__all__ = [
+    "fetch_index_ohlcv",
+    "fetch_indices_ohlcv",
+    "fetch_index_volume",
+    "fetch_trading_volume_by_investor",
+    "fetch_trading_value_by_investor",
+]

--- a/krx/indices.py
+++ b/krx/indices.py
@@ -8,7 +8,7 @@ between the so‑called *kimchi premium* and index returns.
 
 Example
 -------
->>> from fetch_krx import fetch_index_ohlcv
+>>> from krx.indices import fetch_index_ohlcv
 >>> df = fetch_index_ohlcv("KOSPI", "2023-01-01", "2023-01-10")
 >>> print(df.head())
 

--- a/krx/trading.py
+++ b/krx/trading.py
@@ -1,0 +1,63 @@
+"""Trading statistics utilities for KRX markets.
+
+This module provides convenience wrappers around the ``pykrx`` APIs to
+retrieve trading volume and value broken down by investor type (individuals,
+foreigners, institutions, etc.).  The returned objects are ``pandas``
+``DataFrame`` instances indexed by date.
+
+Example
+-------
+>>> from krx.trading import fetch_trading_volume_by_investor
+>>> df = fetch_trading_volume_by_investor("KOSPI", "2023-01-01", "2023-01-10")
+>>> print(df.head())
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+from pykrx import stock
+
+from .indices import _format_date
+
+
+def fetch_trading_volume_by_investor(
+    market: str, start: str, end: str, *, etf: bool = False, etn: bool = False, elw: bool = False
+) -> pd.DataFrame:
+    """Return trading volume by investor type for a market or ticker.
+
+    Parameters
+    ----------
+    market:
+        Ticker or market code (e.g. ``"KOSPI"``).
+    start, end:
+        Date range specified as ``YYYYMMDD`` or ``YYYY-MM-DD``.
+    etf, etn, elw:
+        Include ETFs, ETNs or ELWs in the aggregation.
+    """
+    start = _format_date(start)
+    end = _format_date(end)
+
+    df = stock.get_market_trading_volume_by_investor(
+        start, end, market, etf=etf, etn=etn, elw=elw
+    )
+    df.index = pd.to_datetime(df.index)
+    return df
+
+
+def fetch_trading_value_by_investor(
+    market: str, start: str, end: str, *, on: str | None = None, etf: bool = False, etn: bool = False, elw: bool = False
+) -> pd.DataFrame:
+    """Return trading value by investor type.
+
+    ``pykrx`` does not expose a dedicated function for value-by-investor,
+    but ``get_market_trading_value_by_date`` with ``detail=True`` provides the
+    necessary breakdown.
+    """
+    start = _format_date(start)
+    end = _format_date(end)
+
+    df = stock.get_market_trading_value_by_date(
+        start, end, market, on=on, etf=etf, etn=etn, elw=elw, detail=True
+    )
+    df.index = pd.to_datetime(df.index)
+    return df


### PR DESCRIPTION
## Summary
- Group KRX data helpers into a dedicated `krx` package
- Provide functions to fetch index OHLCV and investor trading statistics

## Testing
- `python -m py_compile krx/*.py`
- `python - <<'PY'\nfrom krx import fetch_index_ohlcv\n\ntry:\n    df = fetch_index_ohlcv("KOSPI", "2023-01-02", "2023-01-05")\n    print(df.head())\nexcept Exception as e:\n    print(f"error: {e.__class__.__name__}: {e}")\nPY`
- `pip install pykrx` *(fails: Could not find a version that satisfies the requirement pykrx)*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_688eee017b648331afda4e4d1f3a7ce4