### PR TITLE
Add KRX index fetch and merge pipelines

### DIFF
--- a/fetch_krx.py
+++ b/fetch_krx.py
@@ -1,0 +1,92 @@
+"""Fetch daily KRX index data and store as CSV files.
+
+This script is intentionally kept separate from the preprocessing pipeline so
+that raw index data can be gathered once and the heavy lifting is not exposed
+when sharing research code.  The downloaded files follow the same column schema
+as the bitcoin and foreign‐exchange data used elsewhere in the project:
+
+``datetime,currency,market,index_name,platform,open,high,low,close,volume,change_pct``
+
+The script relies on :mod:`pykrx` which must be installed in the running
+environment.  The data are fetched using the convenience wrappers defined in
+``krx.indices``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from typing import Iterable
+
+import pandas as pd
+
+from krx.indices import fetch_index_ohlcv
+
+
+# Default indices to download.  Additional tickers/names understood by
+# ``pykrx`` may be supplied if desired.
+DEFAULT_INDICES = ["KOSPI", "KOSDAQ", "KOSPI200", "KOSDAQ150"]
+
+
+def _prepare_dataframe(df: pd.DataFrame, index_name: str) -> pd.DataFrame:
+    """Normalise raw ``pykrx`` output to the project's CSV schema."""
+
+    df = df.rename(
+        columns={
+            "시가": "open",
+            "고가": "high",
+            "저가": "low",
+            "종가": "close",
+            "거래량": "volume",
+        }
+    )
+
+    # ``pykrx`` does not provide day‑to‑day change percentages for indices, so
+    # compute it from the closing prices.
+    df["change_pct"] = df["close"].pct_change() * 100
+
+    df = df.reset_index().rename(columns={"index": "datetime"})
+    df["currency"] = "KRW"
+    df["market"] = "KRX"
+    df["index_name"] = index_name
+    df["platform"] = "KRX"
+
+    return df[
+        [
+            "datetime",
+            "currency",
+            "market",
+            "index_name",
+            "platform",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "change_pct",
+        ]
+    ]
+
+
+def fetch_and_save(indices: Iterable[str], start: str, end: str, out_dir: str) -> None:
+    """Fetch ``indices`` between ``start`` and ``end`` and write to ``out_dir``."""
+
+    os.makedirs(out_dir, exist_ok=True)
+    for idx in indices:
+        df = fetch_index_ohlcv(idx, start, end)
+        df = _prepare_dataframe(df, idx)
+        out_path = os.path.join(out_dir, f"{idx}.csv")
+        df.to_csv(out_path, index=False)
+        print(f"✔ Saved {idx} ({len(df)} rows) to {out_path}")
+
+
+def main() -> None:
+    start = "2010-01-01"
+    end = date.today().strftime("%Y-%m-%d")
+    out_dir = os.path.join("data", "krx_data")
+    fetch_and_save(DEFAULT_INDICES, start, end, out_dir)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,26 +1,31 @@
-import pykrx
-
 #!/usr/bin/env python3
 import os
 import glob
 import pandas as pd
 
+
 def load_aggregated(btc_data_dir: str):
     agg_dfs = []
     for path in glob.glob(os.path.join(btc_data_dir, "bitcoinity_data_*.csv")):
-        currency = os.path.basename(path).replace("bitcoinity_data_", "").replace(".csv", "")
+        currency = (
+            os.path.basename(path)
+            .replace("bitcoinity_data_", "")
+            .replace(".csv", "")
+        )
         df = pd.read_csv(path, parse_dates=["Time"])
         df = df.melt(
             id_vars=["Time"],
             var_name="market",
-            value_name="close"
+            value_name="close",
         ).rename(columns={"Time": "datetime"})
         df["platform"] = "bitcoinity"
         for col in ["open", "high", "low", "volume", "change_pct"]:
             df[col] = pd.NA
         df["currency"] = currency
+        df["index_name"] = pd.NA
         agg_dfs.append(df)
     return agg_dfs
+
 
 def load_exchange_specific(btc_data_dir: str):
     exch_dfs = []
@@ -31,20 +36,24 @@ def load_exchange_specific(btc_data_dir: str):
         currency = parts[0]
         market = parts[1] if len(parts) > 1 else parts[0]
         df = pd.read_csv(path, parse_dates=["날짜"], thousands=",")
-        df = df.rename(columns={
-            "날짜":    "datetime",
-            "시가":     "open",
-            "고가":     "high",
-            "저가":     "low",
-            "종가":     "close",
-            "거래량":   "volume",
-            "변동 %":   "change_pct"
-        })
+        df = df.rename(
+            columns={
+                "날짜": "datetime",
+                "시가": "open",
+                "고가": "high",
+                "저가": "low",
+                "종가": "close",
+                "거래량": "volume",
+                "변동 %": "change_pct",
+            }
+        )
         df["currency"] = currency
         df["platform"] = currency  # e.g. "BRL"
         df["market"] = market      # English platform name
+        df["index_name"] = pd.NA
         exch_dfs.append(df)
     return exch_dfs
+
 
 def load_fx(currency_data_dir: str):
     fx_dfs = []
@@ -52,55 +61,76 @@ def load_fx(currency_data_dir: str):
         fname = os.path.basename(path)
         currency = fname.replace("USD_", "").replace(" 과거 데이터.csv", "")
         df = pd.read_csv(path, parse_dates=["날짜"])
-        df = df.rename(columns={
-            "날짜":    "datetime",
-            "시가":     "open",
-            "고가":     "high",
-            "저가":     "low",
-            "종가":     "close",
-            "거래량":   "volume",
-            "변동 %":   "change_pct"
-        })
+        df = df.rename(
+            columns={
+                "날짜": "datetime",
+                "시가": "open",
+                "고가": "high",
+                "저가": "low",
+                "종가": "close",
+                "거래량": "volume",
+                "변동 %": "change_pct",
+            }
+        )
         df["currency"] = currency
         df["platform"] = currency
         df["market"] = f"USD_{currency}"
+        df["index_name"] = pd.NA
         fx_dfs.append(df)
     return fx_dfs
+
+
+def load_krx(krx_data_dir: str):
+    """Load pre-fetched KRX index data."""
+
+    krx_dfs = []
+    for path in glob.glob(os.path.join(krx_data_dir, "*.csv")):
+        df = pd.read_csv(path, parse_dates=["datetime"])
+        krx_dfs.append(df)
+    return krx_dfs
+
 
 def main():
     btc_data_dir = os.path.join("data", "btc_data")
     currency_data_dir = os.path.join("data", "currency_data")
+    krx_data_dir = os.path.join("data", "krx_data")
 
     agg_dfs = load_aggregated(btc_data_dir)
     exch_dfs = load_exchange_specific(btc_data_dir)
     fx_dfs = load_fx(currency_data_dir)
+    krx_dfs = load_krx(krx_data_dir)
 
-    full = pd.concat(agg_dfs + exch_dfs + fx_dfs, ignore_index=True)
+    full = pd.concat(agg_dfs + exch_dfs + fx_dfs + krx_dfs, ignore_index=True)
 
     full["datetime"] = (
         pd.to_datetime(full["datetime"], utc=True)
-          .dt.tz_convert(None)
+        .dt.tz_convert(None)
     )
 
-    full = full[[
-        "datetime",
-        "currency",
-        "market",
-        "platform",
-        "open",
-        "high",
-        "low",
-        "close",
-        "volume",
-        "change_pct"
-    ]]
+    full = full[
+        [
+            "datetime",
+            "currency",
+            "market",
+            "index_name",
+            "platform",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "change_pct",
+        ]
+    ]
 
     full = full.sort_values("datetime").reset_index(drop=True)
 
     os.makedirs("data", exist_ok=True)
-    output_path = os.path.join("data", "BTC.csv")
+    output_path = os.path.join("data", "BTC_KRX.csv")
     full.to_csv(output_path, index=False)
     print(f"✔ Saved combined data ({len(full)} rows) to {output_path}")
 
+
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- add dedicated script to download KRX index OHLCV data and normalise columns
- extend preprocessing to include KRX indices and add `index_name` field

## Testing
- `python -m py_compile fetch_krx.py preprocess.py krx/*.py`
- `pip install pykrx` *(fails: Could not find a version that satisfies the requirement pykrx)*

------
https://chatgpt.com/codex/tasks/task_e_688f09daa8348331a2d0a1c95ee033e4